### PR TITLE
🚑️ Add bit fields to PROG_values_t structure

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "AS5047P - Arduino Library"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.0.0
+PROJECT_NUMBER         = 3.0.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![GitHub](https://img.shields.io/github/license/jonas-merkle/AS5047P)
 ![GitHub issues](https://img.shields.io/github/issues/jonas-merkle/AS5047P)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/jonas-merkle/AS5047P)
-![Maintenance](https://img.shields.io/maintenance/yes/2025)
+![Maintenance](https://img.shields.io/maintenance/yes/2026)
 
 High-level, type-safe SPI driver for **ams/TA** **AS5047P** (and compatible AS5x47 parts).
 Read 14-bit angles, magnitude, and diagnostics with concise APIs—works on classic Arduino, Feather, Teensy, and other SPI-capable boards.

--- a/examples/BasicReadAngle/BasicReadAngle.ino
+++ b/examples/BasicReadAngle/BasicReadAngle.ino
@@ -8,11 +8,11 @@
  *        AS5047P sensor and prints it to the serial console once per second,
  *        toggling the onboard LED to indicate activity.
  *
- * @version 3.0.0
- * @date 2025-10-07
+ * @version 3.0.1
+ * @date 2026-01-18
  *
  * @copyright
- * Copyright (c) 2024 Jonas Merkle.
+ * Copyright (c) 2026 Jonas Merkle.
  * This project is released under the GPL-3.0 License.
  *
  * @see https://github.com/jonas-merkle/AS5047P

--- a/examples/BasicReadAngleAndDebugInfo/BasicReadAngleAndDebugInfo.ino
+++ b/examples/BasicReadAngleAndDebugInfo/BasicReadAngleAndDebugInfo.ino
@@ -8,11 +8,11 @@
  *        once per second, printing both to the serial console while
  *        toggling the onboard LED to indicate activity.
  *
- * @version 3.0.0
- * @date 2025-10-07
+ * @version 3.0.1
+ * @date 2026-01-18
  *
  * @copyright
- * Copyright (c) 2024 Jonas Merkle.
+ * Copyright (c) 2026 Jonas Merkle.
  * This project is released under the GPL-3.0 License.
  *
  * @see https://github.com/jonas-merkle/AS5047P

--- a/examples/BasicReadAngleWithErrorInfo/BasicReadAngleWithErrorInfo.ino
+++ b/examples/BasicReadAngleWithErrorInfo/BasicReadAngleWithErrorInfo.ino
@@ -7,11 +7,11 @@
  *        The program outputs the current angle and any reported error details
  *        to the serial console once per second while toggling the onboard LED.
  *
- * @version 3.0.0
- * @date 2025-10-07
+ * @version 3.0.1
+ * @date 2026-01-18
  *
  * @copyright
- * Copyright (c) 2024 Jonas Merkle.
+ * Copyright (c) 2026 Jonas Merkle.
  * This project is released under the GPL-3.0 License.
  *
  * @see https://github.com/jonas-merkle/AS5047P

--- a/examples/PrintAllSettings/PrintAllSettings.ino
+++ b/examples/PrintAllSettings/PrintAllSettings.ino
@@ -9,11 +9,11 @@
  *        from the AS5047P sensor and prints each bit field to the serial console
  *        every five seconds.
  *
- * @version 3.0.0
- * @date 2025-10-07
+ * @version 3.0.1
+ * @date 2026-01-18
  *
  * @copyright
- * Copyright (c) 2024 Jonas Merkle.
+ * Copyright (c) 2026 Jonas Merkle.
  * This project is released under the GPL-3.0 License.
  *
  * @see https://github.com/jonas-merkle/AS5047P

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "AS5047P",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "An Arduino library for the AS5047P high-resolution rotary position sensor. Supporting also the following sensor types: AS5047D, AS5147, AS5147P, AS5247",
   "keywords": "arduino-library, as5047p, spi, sensor, rotary-encoder, high-resolution, rotary-position-sensor, as5x47, as5047d, as5147, as5147p, as5247, encoder, rotary, angle, uvw, abi",
   "repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AS5047P
-version=3.0.0
+version=3.0.1
 author=Jonas Merkle [JJM] <jonas@jjm.one>
 maintainer=Jonas Merkle [JJM] <jonas@jjm.one>
 sentence=An Arduino library for the AS5047P high-resolution rotary position sensor.

--- a/src/AS5047P.cpp
+++ b/src/AS5047P.cpp
@@ -6,11 +6,11 @@
  *        Provides high-level read/write helpers, error aggregation utilities,
  *        and user-facing convenience functions for angle and magnitude reads.
  *
- * @version 3.0.0
- * @date 2025-10-07
+ * @version 3.0.1
+ * @date 2026-01-18
  *
  * @copyright
- * Copyright (c) 2024 Jonas Merkle.
+ * Copyright (c) 2026 Jonas Merkle.
  * This project is released under the GPL-3.0 License.
  */
 

--- a/src/AS5047P.h
+++ b/src/AS5047P.h
@@ -6,11 +6,11 @@
  *        Declares the high-level sensor API, read/write helpers for volatile
  *        and non-volatile registers, and optional status/debug utilities.
  *
- * @version 3.0.0
- * @date 2025-10-07
+ * @version 3.0.1
+ * @date 2026-01-18
  *
  * @copyright
- * Copyright (c) 2024 Jonas Merkle.
+ * Copyright (c) 2026 Jonas Merkle.
  * This project is released under the GPL-3.0 License.
  */
 
@@ -105,7 +105,8 @@ public:
 #if defined(__cplusplus) && __cplusplus >= 201402L
     [[deprecated("Use verifyWrittenRegF instead.")]]
 #endif
-    inline bool verifyWittenRegF(uint16_t regAddress, uint16_t expectedData) {
+    inline bool verifyWittenRegF(uint16_t regAddress, uint16_t expectedData)
+    {
         return verifyWrittenRegF(regAddress, expectedData);
     }
 #if defined(AS5047P_STD_STRING_SUPPORT)

--- a/src/spi/AS5047P_SPI_Arduino.cpp
+++ b/src/spi/AS5047P_SPI_Arduino.cpp
@@ -9,11 +9,11 @@
  *        command/data frames, chip-select timing, and the readback NOP
  *        transaction required by the AS5047P.
  *
- * @version 3.0.0
- * @date 2025-10-07
+ * @version 3.0.1
+ * @date 2026-01-18
  *
  * @copyright
- * Copyright (c) 2024 Jonas Merkle.
+ * Copyright (c) 2026 Jonas Merkle.
  * This project is released under the GPL-3.0 License.
  */
 

--- a/src/spi/AS5047P_SPI_Arduino.h
+++ b/src/spi/AS5047P_SPI_Arduino.h
@@ -2,11 +2,13 @@
  * @file AS5047P_SPI_Arduino.h
  * @author Jonas Merkle [JJM] (jonas@jjm.one)
  * @brief This header file contains the Arduino SPI bus handler for the AS5047P Library.
- * @version 2.2.2
- * @date 2024-10-19
  *
- * @copyright Copyright (c) 2024 Jonas Merkle. This project is released under the GPL-3.0 License License.
+ * @version 3.0.1
+ * @date 2026-01-18
  *
+ * @copyright
+ * Copyright (c) 2026 Jonas Merkle.
+ * This project is released under the GPL-3.0 License.
  */
 
 #ifndef AS5047P_SPI_ARDUINO_h

--- a/src/types/AS5047P_Types.cpp
+++ b/src/types/AS5047P_Types.cpp
@@ -4,11 +4,11 @@
  * @brief Implementation of types, frame structures, and helpers used by the
  *        AS5047P library (error reporting, SPI frames, and register wrappers).
  *
- * @version 3.0.0
- * @date 2025-10-07
+ * @version 3.0.1
+ * @date 2026-01-18
  *
  * @copyright
- * Copyright (c) 2024 Jonas Merkle.
+ * Copyright (c) 2026 Jonas Merkle.
  * This project is released under the GPL-3.0 License.
  */
 

--- a/src/types/AS5047P_Types.h
+++ b/src/types/AS5047P_Types.h
@@ -352,8 +352,10 @@ namespace AS5047P_Types
             typedef struct __attribute__((__packed__))
             {
                 uint16_t PROGEN : 1;  ///< Enable programming of OTP memory.
+                uint16_t :1;
                 uint16_t OTPREF : 1;  ///< Refresh non-volatile regs from OTP content.
                 uint16_t PROGOTP : 1; ///< Start OTP programming cycle.
+                uint16_t :2;
                 uint16_t PROGVER : 1; ///< Enable verify phase after programming.
             } PROG_values_t;
 

--- a/src/types/AS5047P_Types.h
+++ b/src/types/AS5047P_Types.h
@@ -2,11 +2,12 @@
  * @file AS5047P_Types.h
  * @author Jonas Merkle [JJM] (jonas@jjm.one)
  * @brief Type definitions used by the AS5047P library (errors, SPI frames, register wrappers).
- * @version 2.2.3
- * @date 2025-10-07
+ *
+ * @version 3.0.1
+ * @date 2026-01-18
  *
  * @copyright
- * Copyright (c) 2024 Jonas Merkle.
+ * Copyright (c) 2026 Jonas Merkle.
  * This project is released under the GPL-3.0 License.
  */
 

--- a/src/util/AS5047P_Settings.h
+++ b/src/util/AS5047P_Settings.h
@@ -2,11 +2,12 @@
  * @file AS5047P_Settings.h
  * @author Jonas Merkle [JJM] (jonas@jjm.one)
  * @brief Library-wide configuration options for the AS5047P library.
- * @version 3.0.0
- * @date 2025-10-07
+ *
+ * @version 3.0.1
+ * @date 2026-01-18
  *
  * @copyright
- * Copyright (c) 2024 Jonas Merkle.
+ * Copyright (c) 2026 Jonas Merkle.
  * This project is released under the GPL-3.0 License.
  */
 

--- a/src/util/AS5047P_Util.h
+++ b/src/util/AS5047P_Util.h
@@ -2,11 +2,12 @@
  * @file AS5047P_Util.h
  * @author Jonas Merkle [JJM] (jonas@jjm.one)
  * @brief Utility helpers for the AS5047P library (bit parity, optional string utils).
- * @version 3.0.0
- * @date 2025-10-07
+ *
+ * @version 3.0.1
+ * @date 2026-01-18
  *
  * @copyright
- * Copyright (c) 2024 Jonas Merkle.
+ * Copyright (c) 2026 Jonas Merkle.
  * This project is released under the GPL-3.0 License.
  */
 


### PR DESCRIPTION
Fixes #53 by adding empty bit fields into the `PROG_values_t` structure